### PR TITLE
Add snapshot resolver

### DIFF
--- a/docs/src/pages/README.md
+++ b/docs/src/pages/README.md
@@ -7,6 +7,7 @@ Gooey is a Scala library for creating user interfaces. It's goal is to make it v
 To use Gooey, add the following to your `build.sbt`
 
 ```scala
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 libraryDependencies += "org.creativescala" %% "gooey" % "@VERSION@"
 ```
 


### PR DESCRIPTION
Until you publish a tagged release there are only snapshot versions available. This confused a user on the Scala Discord.